### PR TITLE
fixes

### DIFF
--- a/app/(protected)/(tabs)/settings/index.tsx
+++ b/app/(protected)/(tabs)/settings/index.tsx
@@ -163,7 +163,7 @@ export default function SettingsScreen() {
         </View>
 
         <Text className="mt-6 mb-6 text-sm font-medium text-center text-gray-500">
-          App Version 0.2
+          App Version 0.3
         </Text>
       </ScrollView>
     );

--- a/services/api.ts
+++ b/services/api.ts
@@ -14,7 +14,7 @@ import axios, { AxiosError, AxiosInstance, AxiosResponse } from "axios";
 import { TOKEN_KEY } from "~/constants";
 const url = process.env.EXPO_PUBLIC_DEV_URL;
 
-const Api: AxiosInstance = axios.create({ baseURL: url });
+const Api: AxiosInstance = axios.create({ baseURL: url + "/api/v1" });
 
 Api.interceptors.request.use(async (config) => {
   const data = await SecureStore.getItemAsync(TOKEN_KEY);

--- a/services/availability.ts
+++ b/services/availability.ts
@@ -1,17 +1,17 @@
 import { Api } from "./api";
 import { Availability } from "./types";
 export const addAvailability = (data: Availability) => {
-  return Api.post("/user/doctor/availability", data);
+  return Api.post("/doctors/availability", data);
 };
 
 export const getDoctorAvailability = (): Promise<Availability[]> => {
-  return Api.get("/user/doctor/availability");
+  return Api.get("/doctors/availability");
 };
 
 export const removeAvailabilityById = (availabilityId: number) => {
-  return Api.delete(`/user/doctor/availability/id/${availabilityId}`);
+  return Api.delete(`/doctors/availability/id/${availabilityId}`);
 };
 
 export const removeAvailabilityByDay = (dayIndex: number) => {
-  return Api.delete(`/user/doctor/availability/day/${dayIndex}`);
+  return Api.delete(`/doctors/availability/day/${dayIndex}`);
 };

--- a/services/doctor.ts
+++ b/services/doctor.ts
@@ -9,10 +9,10 @@ export const getAllDoctors = (
 ): Promise<GetDoctorsResponse> => {
   //YEAH THIS SUCKS
   if (county === null || county === "") {
-    return Api.get(`/user/doctor?page=${page}&sort=${sortBy}&order=${order}`);
+    return Api.get(`/doctors?page=${page}&sort=${sortBy}&order=${order}`);
   }
   return Api.get(
-    `/user/doctor?page=${page}&county=${county}&sort=${sortBy}&order=${order}`,
+    `/doctors?page=${page}&county=${county}&sort=${sortBy}&order=${order}`,
   );
 };
 
@@ -21,7 +21,7 @@ export const requestDoctorTimeSlots = (
   doctor_id: number,
   slot_date: Date,
 ): Promise<AppointmentSlots[]> => {
-  return Api.post(`/user/doctor/slots`, {
+  return Api.post(`/doctors/availability/slots`, {
     day_of_week,
     doctor_id,
     slot_date,

--- a/services/onboarding.ts
+++ b/services/onboarding.ts
@@ -3,10 +3,10 @@ import { patientOnboardingSchema, doctorOnboardingSchema } from "~/types/zod";
 import { Api } from "./api";
 
 const onboardPatient = (values: z.infer<typeof patientOnboardingSchema>) => {
-  return Api.post("/user/patient", values);
+  return Api.post("/patients", values);
 };
 
 const onboardDoctor = (values: z.infer<typeof doctorOnboardingSchema>) => {
-  return Api.post("/user/doctor", values);
+  return Api.post("/doctors", values);
 };
 export { onboardPatient, onboardDoctor };

--- a/services/user.ts
+++ b/services/user.ts
@@ -3,13 +3,13 @@ import { Api } from "./api";
 import z from "zod";
 import { profileSchema } from "~/types/zod";
 const getUser = (): Promise<User> => {
-  return Api.get("/user");
+  return Api.get("/users/me");
 };
 const updateUser = (data: z.infer<typeof profileSchema>) => {
-  return Api.patch("/user", data);
+  return Api.patch("/users/me", data);
 };
 const updateAvatar = (data: FormData) => {
-  return Api.patchForm("/user/profilePicture", data);
+  return Api.patchForm("/users/me/profile-picture", data);
 };
 
 export { getUser, updateUser, updateAvatar };


### PR DESCRIPTION
This pull request includes several changes to update API endpoints and a minor version update in the settings screen. The most important changes include modifying the base URL and updating various endpoints in multiple service files.

API endpoint updates:

* [`services/api.ts`](diffhunk://#diff-a7425397507c9ffa3d7778c28bd1ec960694b814ed386cfdbbf36d9a08c2908dL17-R17): Updated the base URL to include `/api/v1` in the `axios.create` configuration.
* [`services/availability.ts`](diffhunk://#diff-cdbaa07457172ae9afc94815a489251630a653a1cecd09dfee9adfc690486806L4-R16): Updated all availability-related endpoints to use the `/doctors/availability` path instead of `/user/doctor/availability`.
* [`services/doctor.ts`](diffhunk://#diff-92ca2570f0c9e701941d25828106f492772b84531f4043db67ebaef3645ba35aL12-R15): Updated endpoints for fetching doctors and requesting time slots to use the `/doctors` path instead of `/user/doctor`. [[1]](diffhunk://#diff-92ca2570f0c9e701941d25828106f492772b84531f4043db67ebaef3645ba35aL12-R15) [[2]](diffhunk://#diff-92ca2570f0c9e701941d25828106f492772b84531f4043db67ebaef3645ba35aL24-R24)
* [`services/onboarding.ts`](diffhunk://#diff-b3b05c623db0914a54e15b5b551ccf41b945d469d3c4ebd7d1b89b3323e80dddL6-R10): Changed onboarding endpoints to use `/patients` and `/doctors` paths instead of `/user/patient` and `/user/doctor`.
* [`services/user.ts`](diffhunk://#diff-591a157d4f0cc614983847c3db6e31a959198776d8557d0b5723be297827e68cL6-R12): Updated user-related endpoints to use `/users/me` and `/users/me/profile-picture` paths instead of `/user` and `/user/profilePicture`.

Version update:

* [`app/(protected)/(tabs)/settings/index.tsx`](diffhunk://#diff-c4274a3b3ad1e44612984226b007459b9e9e411cd67619e4cb2dfc8ccf311432L166-R166): Updated the app version displayed in the settings screen from `0.2` to `0.3`.