### PR TITLE
Records

### DIFF
--- a/services/documents.ts
+++ b/services/documents.ts
@@ -1,5 +1,15 @@
 import { Api } from "./api";
+import type { Bundle, DocumentReference } from "~/types/fhir";
 
+// Define the structure of the Bundle returned by your API
+interface DocumentReferenceBundle extends Bundle {
+  entry?: { resource: DocumentReference }[]; // Specify the resource type in entry
+}
 export function UploadPatientDocument(data: FormData) {
   return Api.post("/documents/upload", data);
+}
+
+export function GetPatientDocuments(): Promise<DocumentReferenceBundle> {
+  //TODO: Append patient parameters
+  return Api.get("/documents");
 }

--- a/types/fhir.ts
+++ b/types/fhir.ts
@@ -1,5 +1,91 @@
 // FHIR Standard Resource Types
 
+// Bundle Resource
+export interface Bundle {
+  resourceType: "Bundle";
+  id?: string;
+  meta?: Meta;
+  type: BundleType;
+  total?: number;
+  link?: BundleLink[];
+  entry?: BundleEntry[];
+  signature?: Signature;
+  timestamp?: string;
+}
+
+export type BundleType =
+  | "document"
+  | "message"
+  | "transaction"
+  | "transaction-response"
+  | "batch"
+  | "batch-response"
+  | "history"
+  | "searchset"
+  | "collection";
+
+export interface BundleLink {
+  relation: string;
+  url: string;
+}
+
+export interface BundleEntry {
+  fullUrl?: string;
+  resource?: Resource;
+  search?: BundleEntrySearch;
+  request?: BundleEntryRequest;
+  response?: BundleEntryResponse;
+}
+
+export interface BundleEntrySearch {
+  mode?: "match" | "include" | "outcome";
+  score?: number;
+}
+
+export interface BundleEntryRequest {
+  method: "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "PATCH";
+  url: string;
+  ifNoneMatch?: string;
+  ifModifiedSince?: string;
+  ifMatch?: string;
+  ifNoneExist?: string;
+}
+
+export interface BundleEntryResponse {
+  status: string;
+  location?: string;
+  etag?: string;
+  lastModified?: string;
+  outcome?: Resource;
+}
+
+export interface Meta {
+  versionId?: string;
+  lastUpdated?: string;
+  source?: string;
+  profile?: string[];
+  security?: Coding[];
+  tag?: Coding[];
+}
+
+export interface Signature {
+  type: Coding[];
+  when: string;
+  who: Reference;
+  onBehalfOf?: Reference;
+  targetFormat?: string;
+  sigFormat?: string;
+  data?: string;
+}
+
+export interface Resource {
+  resourceType: string;
+  id?: string;
+  meta?: Meta;
+  implicitRules?: string;
+  language?: string;
+}
+
 // Patient Resource
 export interface Patient {
   resourceType: "Patient";


### PR DESCRIPTION
This pull request introduces functionality for handling FHIR `Bundle` resources and retrieving patient documents via the API. It includes type definitions for FHIR `Bundle` and related structures, as well as a new API method to fetch patient documents.

### Additions to FHIR type definitions:
* [`types/fhir.ts`](diffhunk://#diff-921b06b73fe973e77e3652b6e10d409941c9bae7c142a6dd6578309481568aa5R3-R88): Added a comprehensive type definition for the `Bundle` resource, including related types such as `BundleEntry`, `BundleLink`, `Meta`, `Signature`, and `Resource`. This enables structured handling of FHIR `Bundle` resources in the application.

### New API functionality:
* [`services/documents.ts`](diffhunk://#diff-c119bf6725fc99ca040c1389776b1b5dff31673da76c2860edc25e8d57360ea7R2-R15): Introduced a new `GetPatientDocuments` function to retrieve patient documents from the API. This function returns a `DocumentReferenceBundle`, a specialized type of `Bundle` containing `DocumentReference` resources.