### PR TITLE
Records

### DIFF
--- a/hooks/usePatientDocuments.ts
+++ b/hooks/usePatientDocuments.ts
@@ -1,0 +1,55 @@
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+// Make sure fetchPatientDocuments is correctly imported (adjust path if needed)
+import { GetPatientDocuments as fetchPatientDocuments } from "@/services/documents"; // Renaming on import for clarity
+import { Bundle, DocumentReference } from "@/types/fhir"; // Your FHIR types
+import { Role } from "~/providers/AuthProvider";
+
+// Define the structure of the Bundle again or import if defined elsewhere
+interface DocumentReferenceBundle extends Bundle {
+  entry?: { resource: DocumentReference }[];
+}
+
+// Type for the query key for better type safety
+type PatientDocumentsQueryKey = ["patientDocuments", number | undefined];
+
+export const usePatientDocuments = (
+  role: Role,
+  patientId?: number,
+): UseQueryResult<DocumentReference[], Error> => {
+  // <-- Explicit return type added
+  return useQuery<
+    DocumentReferenceBundle, // TQueryFnData: Type returned by queryFn (fetchPatientDocuments)
+    Error, // TError: Type of error thrown
+    DocumentReference[], // TData: Final data type after select function
+    PatientDocumentsQueryKey // TQueryKey: Type of the query key array
+  >({
+    // Pass generics to useQuery
+    queryKey: ["patientDocuments", patientId], // Use the defined query key type
+    queryFn: () => {
+      if (!patientId && role === Role.SPECIALIST) {
+        // Throwing an error here is okay, or return Promise.reject()
+        // React Query handles queryFn errors
+        throw new Error("Patient ID is required");
+        // return Promise.reject(new Error("Patient ID is required")); // Alternative
+      }
+      // Assuming fetchPatientDocuments expects string or number and returns the Bundle promise
+      return fetchPatientDocuments({ patientId: patientId });
+    },
+    select: (bundle: DocumentReferenceBundle): DocumentReference[] => {
+      // Type input to select
+      // Safely extract DocumentReference resources
+      return (
+        bundle.entry
+          ?.map((entry) => entry.resource)
+          .filter(
+            (
+              resource,
+            ): resource is DocumentReference => // Type guard is good
+              resource?.resourceType === "DocumentReference",
+          ) ?? [] // Default to empty array if entry is null/undefined
+      );
+    },
+    // Keep query enabled only when patientId is truthy
+    // enabled: !!patientId,
+  });
+};

--- a/hooks/usePatientDocuments.ts
+++ b/hooks/usePatientDocuments.ts
@@ -32,7 +32,6 @@ export const usePatientDocuments = (
         throw new Error("Patient ID is required");
         // return Promise.reject(new Error("Patient ID is required")); // Alternative
       }
-      // Assuming fetchPatientDocuments expects string or number and returns the Bundle promise
       return fetchPatientDocuments({ patientId: patientId });
     },
     select: (bundle: DocumentReferenceBundle): DocumentReference[] => {
@@ -42,14 +41,11 @@ export const usePatientDocuments = (
         bundle.entry
           ?.map((entry) => entry.resource)
           .filter(
-            (
-              resource,
-            ): resource is DocumentReference => // Type guard is good
+            (resource): resource is DocumentReference =>
               resource?.resourceType === "DocumentReference",
-          ) ?? [] // Default to empty array if entry is null/undefined
+          ) ?? [] // defaults to empty array if entry is null/undefined
       );
     },
-    // Keep query enabled only when patientId is truthy
     // enabled: !!patientId,
   });
 };

--- a/services/documents.ts
+++ b/services/documents.ts
@@ -8,8 +8,16 @@ interface DocumentReferenceBundle extends Bundle {
 export function UploadPatientDocument(data: FormData) {
   return Api.post("/documents/upload", data);
 }
-
-export function GetPatientDocuments(): Promise<DocumentReferenceBundle> {
+interface GetPatientDocumentParams {
+  patientId?: number;
+}
+export function GetPatientDocuments(
+  params: GetPatientDocumentParams,
+): Promise<DocumentReferenceBundle> {
   //TODO: Append patient parameters
-  return Api.get("/documents");
+  const urlParams = new URLSearchParams();
+  if (params.patientId)
+    urlParams.append("patient_id", params.patientId.toString());
+  const queryString = urlParams.toString();
+  return Api.get(`/documents${queryString ? "?" + queryString : ""}`);
 }

--- a/services/documents.ts
+++ b/services/documents.ts
@@ -14,7 +14,6 @@ interface GetPatientDocumentParams {
 export function GetPatientDocuments(
   params: GetPatientDocumentParams,
 ): Promise<DocumentReferenceBundle> {
-  //TODO: Append patient parameters
   const urlParams = new URLSearchParams();
   if (params.patientId)
     urlParams.append("patient_id", params.patientId.toString());


### PR DESCRIPTION
This pull request refactors the `RecordsScreen` component to replace mock data with real patient documents fetched via a new custom hook, `usePatientDocuments`. It also improves error handling and loading states, and updates the API service to support query parameters for fetching patient documents. Below are the key changes:

### Refactoring `RecordsScreen` to use real data:
* Replaced the use of mock data and manual state management with the `usePatientDocuments` hook, which fetches patient documents based on the user's role and patient ID. Removed the previous `loadData` and `onRefresh` logic. (`app/(protected)/(drawer)/records/index.tsx`, [app/(protected)/(drawer)/records/index.tsxR14-R23](diffhunk://#diff-fd9d8f79af38d5215de8653503137710186a0cfbdda381c605864c29b8994b88R14-R23))
* Added error and loading state handling to the `RecordsScreen` component, displaying an error message or a loader when appropriate. (`app/(protected)/(drawer)/records/index.tsx`, [app/(protected)/(drawer)/records/index.tsxL50-R51](diffhunk://#diff-fd9d8f79af38d5215de8653503137710186a0cfbdda381c605864c29b8994b88L50-R51))

### New `usePatientDocuments` hook:
* Introduced `usePatientDocuments`, a custom hook built on `react-query` to fetch and process patient documents. It includes robust type definitions and a `select` function to extract `DocumentReference` resources from the API response. (`hooks/usePatientDocuments.ts`, [hooks/usePatientDocuments.tsR1-R55](diffhunk://#diff-89e3a85e628a405460cbef12efd39489b67e79964a57e8b3cdddba240dc2ee3eR1-R55))

### Updates to the API service:
* Modified the `GetPatientDocuments` function to accept query parameters, enabling filtering by patient ID. This change supports dynamic fetching of patient-specific documents. (`services/documents.ts`, [services/documents.tsL11-R22](diffhunk://#diff-c119bf6725fc99ca040c1389776b1b5dff31673da76c2860edc25e8d57360ea7L11-R22))

### Cleanup:
* Removed unused imports and state variables related to the old mock data implementation. (`app/(protected)/(drawer)/records/index.tsx`, [[1]](diffhunk://#diff-fd9d8f79af38d5215de8653503137710186a0cfbdda381c605864c29b8994b88L1-L4) [[2]](diffhunk://#diff-fd9d8f79af38d5215de8653503137710186a0cfbdda381c605864c29b8994b88L111-L113)